### PR TITLE
Fix team paramater returning the same result

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -5,7 +5,7 @@ get "/" do
   @req = Rack::Request.new(env)
   @date = Date.today.jd
   if @req.params.include?("team")
-    @date *= @req.params["team"].to_i(36)
+    @date *= @req.params["team"].gsub(/[^A-z]/i, '').to_i(36)
   end
   @lunch_options =  %w(
     Mums-deli


### PR DESCRIPTION
The .to_i(36) method stops generating a number if it runs into a non
alphanumeric character so this strips anything but letters from the
param and should now reliably give a different random seed for each team name.